### PR TITLE
Changed the install instructions to also make it run on MacOS. fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run it from source:
 1. Install MPV globally (`brew install mpv` on macOS, [various repos][mpv-repos]
    on Linux, but no idea about Windows)
 2. `git clone https://github.com/Songbee/desktop`
-3. `npm install && gulp && npm start` (I said npm? Of course I meant [yarn][]!)
+3. `npm install && gulp && npm run build && npm start` (I said npm? Of course I meant [yarn][]!)
 
 ## FAQ-like section
 


### PR DESCRIPTION
Since I use a Mac anyway I thought I give it a try.

This simple command made it possible to build and run the application on Mac OS. For future releases I'd suggest using the Release functionality of github and provide actual Electron Apps to just download and run.

I did stuff with the CLA-Assistant, I have no idea about it however and how it works and if it works for this pull request. I created a CLA gist and linked it to CLA, maybe it works?